### PR TITLE
Fixed NameSpace Mismatch

### DIFF
--- a/src/Exceptions/InvalidPathException.php
+++ b/src/Exceptions/InvalidPathException.php
@@ -1,5 +1,5 @@
 <?php
-namespace NsCreed\MigrationPath;
+namespace NsCreed\MigrationPath\Exceptions;
 
 
 use Exception;


### PR DESCRIPTION
**Deprecation Notice:** Class **NsCreed\MigrationPath\InvalidPathException** located in .**/vendor/nscreed/laravel-migration-paths/src/Exceptions/InvalidPathException.php** does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201